### PR TITLE
Fix #103: Use versioned-dirs only for unfiltered vendoring

### DIFF
--- a/cargo/src/vendor.rs
+++ b/cargo/src/vendor.rs
@@ -90,8 +90,6 @@ pub fn vendor(
     let mut vendor_options: Vec<OsString> =
         vec!["--manifest-path".into(), manifest_path.as_ref().into()];
 
-    vendor_options.push("--versioned-dirs".into());
-
     for ex_path in extra_manifest_paths {
         vendor_options.push("--sync".into());
         vendor_options.push(ex_path.as_ref().into());
@@ -120,6 +118,8 @@ pub fn vendor(
     } else {
         // cargo-vendor-filterer doesn't support `-vv`
         vendor_options.push("-vv".into());
+        // cargo-vendor-filterer doesn't support `--versioned-dirs` either
+        vendor_options.push("--versioned-dirs".into());
         // Enforce lock is up-to-date despite the fact we are regenerating the locks
         if respect_lockfile {
             // NOTE: Only vendor has the --locked option


### PR DESCRIPTION
cargo-vendor-filterer does not support this flag yet