### PR TITLE
Create bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,28 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**obs-service-cargo version (run`rpm -qa | grep obs-service-cargo`)**
+
+**To Reproduce**
+Replace this line with a link to the specfile and _service file in question.
+
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Additional context**
+Add any other context about the problem here.


### PR DESCRIPTION
So that people know they should include the version of obs-service-cargo along with their specfile and _service file in their bug report